### PR TITLE
Parsing performances optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 demo-dist
 node_modules
+*.log
+
+benchmark
+.idea

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wavefront-obj-parser",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Parse wavefront .obj files into json",
   "main": "src/wavefront-obj-parser.js",
   "bin": {

--- a/src/wavefront-obj-parser.js
+++ b/src/wavefront-obj-parser.js
@@ -2,47 +2,50 @@ module.exports = ParseWavefrontObj
 
 // Map .obj vertex info line names to our returned property names
 var vertexInfoNameMap = {v: 'vertex', vt: 'uv', vn: 'normal'}
-// The returned properties that we will populate
-var parsedProperties = ['normal', 'uv', 'vertex', 'normalIndex', 'uvIndex', 'vertexIndex']
+
 function ParseWavefrontObj (wavefrontString) {
+  'use strict'
+
   var parsedJSON = {normal: [], uv: [], vertex: [], normalIndex: [], uvIndex: [], vertexIndex: []}
 
   var linesInWavefrontObj = wavefrontString.split('\n')
 
+  var currentLine, currentLineTokens, vertexInfoType, i, k
+
   // Loop through and parse every line in our .obj file
-  linesInWavefrontObj.forEach(function (currentLine) {
+  for (i = 0; i < linesInWavefrontObj.length; i++) {
+    currentLine = linesInWavefrontObj[i]
     // Tokenize our current line
-    var currentLineTokens = currentLine.split(' ')
+    currentLineTokens = currentLine.split(' ')
     // vertex position, vertex texture, or vertex normal
-    var vertexInfoType = vertexInfoNameMap[currentLineTokens[0]]
+    vertexInfoType = vertexInfoNameMap[currentLineTokens[0]]
+
     if (vertexInfoType) {
-      parsedJSON[vertexInfoType] = parsedJSON[vertexInfoType].concat(currentLineTokens.slice(1))
-      return
+      for (k = 1; k < currentLineTokens.length; k++) {
+        parsedJSON[vertexInfoType].push(parseFloat(currentLineTokens[k]))
+      }
+      continue
     }
+
     if (currentLineTokens[0] === 'f') {
       // Get our 4 sets of vertex, uv, and normal indices for this face
-      for (var i = 1; i < 5; i++) {
+      for (k = 1; k < 5; k++) {
         // If there is no fourth face entry then this is specifying a triangle
         // in this case we push `-1`
         // Consumers of this module should check for `-1` before expanding face data
-        if (i === 4 && !currentLineTokens[4]) {
+        if (k === 4 && !currentLineTokens[4]) {
           parsedJSON.vertexIndex.push(-1)
           parsedJSON.uvIndex.push(-1)
           parsedJSON.normalIndex.push(-1)
         } else {
-          var indices = currentLineTokens[i].split('/')
-          parsedJSON.vertexIndex.push(Number(indices[0]) - 1) // We zero index
-          parsedJSON.uvIndex.push(Number(indices[1]) - 1) // our face indices
-          parsedJSON.normalIndex.push(Number(indices[2]) - 1) // by subtracting 1
+          var indices = currentLineTokens[k].split('/')
+          parsedJSON.vertexIndex.push(parseInt(indices[0], 10) - 1) // We zero index
+          parsedJSON.uvIndex.push(parseInt(indices[1], 10) - 1) // our face indices
+          parsedJSON.normalIndex.push(parseInt(indices[2], 10) - 1) // by subtracting 1
         }
       }
     }
-  })
-  // Convert our parsed strings into floats (trims trailing insignificant `0`s)
-  parsedProperties.forEach(function (property) {
-    parsedJSON[property] = parsedJSON[property].reduce(function (accumulator, nextValue) {
-      return accumulator.concat(parseFloat(nextValue))
-    }, [])
-  })
+  }
+
   return parsedJSON
 }


### PR DESCRIPTION
I've been using this module without much issue for some time but lately I had to convert huge OBJ models to json with some custom mapping for indexed Three.js BufferGeometries and it was taking a considerable amount of time (about 30 minutes for some models). After some profiling, I figured the parsing was the bottleneck. Here is my attempt at fixing it.

For reference, on my MBP late 2013, the time to parse my [test file](https://github.com/chinedufn/wavefront-obj-parser/files/1014895/core.obj.zip) (33kB, zip) went from `2050ms` to `38ms` with node v6.x.

All the tests and code-style checks are still passing.

**Edit:** Just checked using the big files which were taking 30+ minutes, it's now a matter of less than 10 seconds.