### PR TITLE
Fix whitespace parsing

### DIFF
--- a/src/wavefront-obj-parser.js
+++ b/src/wavefront-obj-parser.js
@@ -16,7 +16,7 @@ function ParseWavefrontObj (wavefrontString) {
   for (i = 0; i < linesInWavefrontObj.length; i++) {
     currentLine = linesInWavefrontObj[i]
     // Tokenize our current line
-    currentLineTokens = currentLine.split(' ')
+    currentLineTokens = currentLine.trim().split(/\s+/)
     // vertex position, vertex texture, or vertex normal
     vertexInfoType = vertexInfoNameMap[currentLineTokens[0]]
 

--- a/test/api.js
+++ b/test/api.js
@@ -21,3 +21,33 @@ test('Parse file where some faces are triangles with only 3 values', function (t
   t.plan(1)
   t.deepEqual(objParse(treeObjString), expectedTreeJSON)
 })
+
+test('Handle whitespace inside a single line', function (t) {
+  var testString = 'v  0.1 0.2 0.3\nv  0.2 0.1 0.3\n'
+  var expectedJSON = {
+    vertexNormals: [],
+    vertexUVs: [],
+    vertexPositions: [0.1, 0.2, 0.3, 0.2, 0.1, 0.3],
+    vertexNormalIndices: [],
+    vertexUVIndices: [],
+    vertexPositionIndices: []
+  }
+
+  t.plan(1)
+  t.deepEqual(objParse(testString), expectedJSON)
+})
+
+test('Handle trailing line whitespace', function (t) {
+  var testString = 'v 0.1 0.2 0.3 \n v 0.2 0.1 0.3 \n '
+  var expectedJSON = {
+    vertexNormals: [],
+    vertexUVs: [],
+    vertexPositions: [0.1, 0.2, 0.3, 0.2, 0.1, 0.3],
+    vertexNormalIndices: [],
+    vertexUVIndices: [],
+    vertexPositionIndices: []
+  }
+
+  t.plan(1)
+  t.deepEqual(objParse(testString), expectedJSON)
+})


### PR DESCRIPTION
First of all, great library. It saved me some time!

I have had some problems when parsing an *.obj file I downloaded from the Internet.

It had two spaces after the initial token and another space at the end of the line, like so:
```
v  0.025350 0.026363 -0.050675 \n
```

It produced `null` values quite often.

I added a test for that case and fixed the parsing process by trimming each line and then splitting by multiple whitespace characters with a regex, instead of just a space as the delimiter.